### PR TITLE
Fixed the previously broken Go Character escaping while constructing terminal command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -110,19 +110,19 @@ if (useFile) {
   for (let idx = 0; idx < helmSecrets.length; idx++) {
     const dto = helmSecrets[idx];
     helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmSecretVariableName}[${idx}].key='${dto.key}' \\\n  `);
-    helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmSecretVariableName}[${idx}].value='${dto.value}' \\\n  `);
+    helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmSecretVariableName}[${idx}].value='${getValue(dto)}' \\\n  `);
   }
 
   for (let idx = 0; idx < helmConfigMaps.length; idx++) {
     const dto = helmConfigMaps[idx];
     helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmConfigMapVariableName}[${idx}].key='${dto.key}' \\\n  `);
-    helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmConfigMapVariableName}[${idx}].value='${dto.value}' \\\n  `);
+    helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmConfigMapVariableName}[${idx}].value='${getValue(dto)}' \\\n  `);
   }
 
   for (let idx = 0; idx < helmEnvVars.length; idx++) {
     const dto = helmEnvVars[idx];
     helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmEnvVarVariableName}[${idx}].name='${dto.name}' \\\n  `);
-    helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmEnvVarVariableName}[${idx}].value='${dto.value}' \\\n  `);
+    helmDeploymentCommand = helmDeploymentCommand.concat(`--set ${helmEnvVarVariableName}[${idx}].value='${getValue(dto)}' \\\n  `);
   }
 
   if (helmChartVersion) {


### PR DESCRIPTION
## Changes

* Fixed the previously broken Go Character escaping while constructing terminal command

## Summary

This pull request updates how values are set in the Helm deployment command construction logic in `src/main.ts`. Instead of directly using the `.value` property from each data object, it now calls a `getValue(dto)` function for secrets, config maps, and environment variables. This change centralizes and potentially standardizes value extraction, which can help with consistency and future extensibility.

**Deployment command construction improvements:**

* Updated the logic for setting values in the Helm deployment command for secrets, config maps, and environment variables to use the `getValue(dto)` function instead of accessing the `.value` property directly. This change improves consistency and allows for more flexible handling of values.